### PR TITLE
記事タイトルCSS変更

### DIFF
--- a/app/src/components/post/PostTitle.tsx
+++ b/app/src/components/post/PostTitle.tsx
@@ -6,7 +6,7 @@ type Props = {
 
 export function PostTitle({ children }: Props) {
   return (
-    <h1 className="text-xl md:text-3xl lg:text-4xl md:font-semibold tracking-tight leading-tight md:leading-none mb-12 text-center md:text-left">
+    <h1 className="!text-xl md:!text-3xl md:font-semibold tracking-tight leading-tight md:leading-none mb-12 text-center md:text-left">
       {children}
     </h1>
   );


### PR DESCRIPTION
記事本文は、.zncクラス配下であり、ライブラリのCSSが適用される
スマホで見ると全体的に文字がかなり大きいが、修正したい場合はglobals.cssに直書きする必要がある